### PR TITLE
[OMNI-28518] Adding correct exception when client is not found in remote config.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /vendor
 /.phpintel
+/.idea
 
 composer.lock
 .buildpath

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /.phpintel
 
 composer.lock
+.buildpath
+.project
+.settings
+

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=7.0",
         "guzzlehttp/guzzle": "~6.0",
-        "illuminate/support": "~5.4",
+        "illuminate/support": "~5.4|^6.*",
         "symfony/cache": "~3.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Client for remote config",
     "type": "library",
     "license": "MIT",
-    "version": "1.3.6",
+    "version": "1.4.0",
     "authors": [
         {
             "name": "flaviozantut",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Client for remote config",
     "type": "library",
     "license": "MIT",
-    "version": "1.3.5",
+    "version": "1.3.6",
     "authors": [
         {
             "name": "flaviozantut",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Client for remote config",
     "type": "library",
     "license": "MIT",
-    "version": "1.3.3",
+    "version": "1.3.4",
     "authors": [
         {
             "name": "flaviozantut",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=7.0",
         "guzzlehttp/guzzle": "~6.0",
-        "illuminate/support": "~5.4|~6.x-dev",
+        "illuminate/support": "~6.*",
         "symfony/cache": "~3.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Client for remote config",
     "type": "library",
     "license": "MIT",
-    "version": "1.3.4",
+    "version": "1.3.5",
     "authors": [
         {
             "name": "flaviozantut",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=7.0",
         "guzzlehttp/guzzle": "~6.0",
-        "illuminate/support": "~5.4|^6.*",
+        "illuminate/support": "~5.4|~6.x-dev",
         "symfony/cache": "~3.3"
     },
     "require-dev": {
@@ -25,5 +25,4 @@
             "Linx\\RemoteConfigClient\\": "src/"
         }
     }
-
 }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Client for remote config",
     "type": "library",
     "license": "MIT",
-    "version": "1.2.0",
+    "version": "1.3.3",
     "authors": [
         {
             "name": "flaviozantut",
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=7.0",
         "guzzlehttp/guzzle": "~6.0",
-        "illuminate/support": "~6.*",
+        "illuminate/support": "~5.4|~6.0|~8.0",
         "symfony/cache": "~3.3"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,12 @@
     "require": {
         "php": ">=7.0",
         "guzzlehttp/guzzle": "~6.0",
-        "illuminate/support": "~5.4"
+        "illuminate/support": "~5.4",
+        "symfony/cache": "~3.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5.7"
+        "phpunit/phpunit": "~5.7",
+        "mockery/mockery": "^0.9.9"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Client for remote config",
     "type": "library",
     "license": "MIT",
-    "version": "1.0.1",
+    "version": "1.2.0",
     "authors": [
         {
             "name": "flaviozantut",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Client for remote config",
     "type": "library",
     "license": "MIT",
-    "version": "0.0.3",
+    "version": "1.0.0",
     "authors": [
         {
             "name": "flaviozantut",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Client for remote config",
     "type": "library",
     "license": "MIT",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "authors": [
         {
             "name": "flaviozantut",

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Client for remote config",
     "type": "library",
     "license": "MIT",
+    "version": "0.0.3",
     "authors": [
         {
             "name": "flaviozantut",

--- a/config/remote-config.php
+++ b/config/remote-config.php
@@ -7,4 +7,5 @@ return [
     'environment' => env('REMOTE_CONFIG_ENVIRONMENT', env('APP_ENV')),
     'cache-life-time' => env('REMOTE_CONFIG_CACHE_LIFE_TIME', 3600),
     'cache-directory' => env('REMOTE_CONFIG_CACHE_DIRECTORY'),
+    'logger-class' => env('REMOTE_CONFIG_LOGGER_CLASS', ''),
 ];

--- a/config/remote-config.php
+++ b/config/remote-config.php
@@ -5,4 +5,6 @@ return [
     'password'  => env('REMOTE_CONFIG_PASSWORD', ''),
     'application' => env('REMOTE_CONFIG_APPLICATION', ''),
     'environment' => env('REMOTE_CONFIG_ENVIRONMENT', 'development'),
+    'cache-life-time' => env('REMOTE_CONFIG_CACHE_LIFE_TIME', 3600),
+    'cache-directory' => env('REMOTE_CONFIG_CACHE_DIRECTORY'),
 ];

--- a/config/remote-config.php
+++ b/config/remote-config.php
@@ -4,7 +4,7 @@ return [
     'username'  => env('REMOTE_CONFIG_USERNAME', ''),
     'password'  => env('REMOTE_CONFIG_PASSWORD', ''),
     'application' => env('REMOTE_CONFIG_APPLICATION', ''),
-    'environment' => env('REMOTE_CONFIG_ENVIRONMENT', 'development'),
+    'environment' => env('REMOTE_CONFIG_ENVIRONMENT', env('APP_ENV')),
     'cache-life-time' => env('REMOTE_CONFIG_CACHE_LIFE_TIME', 3600),
     'cache-directory' => env('REMOTE_CONFIG_CACHE_DIRECTORY'),
 ];

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -187,6 +187,12 @@ class RemoteConfig
 
     public function setLoggerClass(string $loggerClass)
     {
+        if (!class_exists($loggerClass)) {
+            return;
+        }
+        if (!method_exists($loggerClass, 'error')) {
+            return;
+        }
         $this->loggerClass = $loggerClass;
     }
 

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -3,6 +3,7 @@
 namespace Linx\RemoteConfigClient;
 
 use GuzzleHttp\Client;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Cache\Simple\FilesystemCache;
 use Psr\SimpleCache\CacheInterface;
 use GuzzleHttp\Exception\ConnectException;
@@ -187,10 +188,7 @@ class RemoteConfig
 
     public function setLoggerClass(string $loggerClass)
     {
-        if (!class_exists($loggerClass)) {
-            return;
-        }
-        if (!method_exists($loggerClass, 'error')) {
+        if ($loggerClass instanceof LoggerInterface) {
             return;
         }
         $this->loggerClass = $loggerClass;

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -158,7 +158,7 @@ class RemoteConfig
                 $exceptionMessage = $re->getMessage();
 
                 if ($re->getResponse()->getStatusCode() === 404)
-                    $exceptionMessage = "clienteId is invalid!";
+                    $exceptionMessage = "clientId is invalid!";
 
                 throw new HttpException($re->getResponse()->getStatusCode(), $exceptionMessage);
             }

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -87,20 +87,13 @@ class RemoteConfig
 
         if ($hasCache) {
             $data = $cache->get($cacheKey);
-
             if (!$this->cacheFallback()->has($cacheKey)) {
                 $this->cacheFallback()->set($cacheKey, $data, self::RC_CACHE_FALLBACK_TTL);
             }
         } else {
-
-            try {
-                $data = $this->httpGet($uri);
-
-                if ($canAcessRedis) {
-                    $cache->set($cacheKey, $data, $this->cacheLifeTime);
-                }
-            } catch (HttpException $th) {
-                throw $th;
+            $data = $this->httpGet($uri);
+            if ($canAcessRedis) {
+                $cache->set($cacheKey, $data, $this->cacheLifeTime);
             }
         }
 
@@ -154,7 +147,7 @@ class RemoteConfig
                     'path' => $path,
                     'timeout' => $timeout,
                 ]);
-                
+
                 $exceptionMessage = $re->getMessage();
 
                 if ($re->getResponse()->getStatusCode() === 404)

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -147,16 +147,20 @@ class RemoteConfig
 
             $cache->set($cacheKey, $currentCache, self::RC_CACHE_FALLBACK_TTL);
         } catch (RequestException $re) {
-            $this->logError('Could not get data from Remote Config API because clienteId is invalid', [
-                'current_cache' => $currentCache,
-                'error_message' => $re->getMessage(),
-                'path' => $path,
-                'timeout' => $timeout,
-            ]);
             if ($re->hasResponse()) {
-                if ($re->getResponse()->getStatusCode() === 404) {
-                    throw new HttpException(404, "clienteId is invalid!");
-                }
+                $this->logError('Could not get data from Remote Config API', [
+                    'current_cache' => $currentCache,
+                    'error_message' => $re->getMessage(),
+                    'path' => $path,
+                    'timeout' => $timeout,
+                ]);
+                
+                $exceptionMessage = $re->getMessage();
+
+                if ($re->getResponse()->getStatusCode() === 404)
+                    $exceptionMessage = "clienteId is invalid!";
+
+                throw new HttpException($re->getResponse()->getStatusCode(), $exceptionMessage);
             }
         }
 

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -123,7 +123,9 @@ class RemoteConfig
                     'timeout' => $timeout,
                 ]
             );
-            $cache->set($cacheKey, json_decode($response->getBody(), true), self::RC_CACHE_FALLBACK_TTL);
+
+            $currentCache = json_decode($response->getBody(), true);
+            $cache->set($cacheKey, $currentCache, self::RC_CACHE_FALLBACK_TTL);
         } catch (ConnectException $e) {
             $this->logError('Could not get data from Remote Config API', [
                 'current_cache' => $currentCache,
@@ -138,7 +140,7 @@ class RemoteConfig
             $cache->set($cacheKey, $currentCache, self::RC_CACHE_FALLBACK_TTL);
         }
 
-        return $cache->get($cacheKey);
+        return $currentCache;
     }
 
     private function cacheFallback()

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -5,8 +5,10 @@ namespace Linx\RemoteConfigClient;
 use GuzzleHttp\Client;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Cache\Simple\FilesystemCache;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Psr\SimpleCache\CacheInterface;
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\RequestException;
 use Illuminate\Support\Arr;
 
 class RemoteConfig
@@ -90,9 +92,15 @@ class RemoteConfig
                 $this->cacheFallback()->set($cacheKey, $data, self::RC_CACHE_FALLBACK_TTL);
             }
         } else {
-            $data = $this->httpGet($uri);
-            if ($canAcessRedis) {
-                $cache->set($cacheKey, $data, $this->cacheLifeTime);
+
+            try {
+                $data = $this->httpGet($uri);
+
+                if ($canAcessRedis) {
+                    $cache->set($cacheKey, $data, $this->cacheLifeTime);
+                }
+            } catch (HttpException $th) {
+                throw $th;
             }
         }
 
@@ -138,6 +146,18 @@ class RemoteConfig
             }
 
             $cache->set($cacheKey, $currentCache, self::RC_CACHE_FALLBACK_TTL);
+        } catch (RequestException $re) {
+            $this->logError('Could not get data from Remote Config API because clienteId is invalid', [
+                'current_cache' => $currentCache,
+                'error_message' => $re->getMessage(),
+                'path' => $path,
+                'timeout' => $timeout,
+            ]);
+            if ($re->hasResponse()) {
+                if ($re->getResponse()->getStatusCode() === 400) {
+                    throw new HttpException(404, "clienteId is invalid!");
+                }
+            }
         }
 
         return $currentCache;

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -62,17 +62,18 @@ class RemoteConfig
             }
             $hasCache = $cache->has($cacheKey);
             $canAcessRedis = true;
-        } catch (\Exception $th) {}
+        } catch (\Exception $th) {
+        }
 
         if ($hasCache) {
             $data = $cache->get($cacheKey);
 
-            if(!$this->cacheFallback()->has($cacheKey)) {
+            if (!$this->cacheFallback()->has($cacheKey)) {
                 $this->cacheFallback()->set($cacheKey, $data, self::RC_CACHE_FALLBACK_TTL);
             }
         } else {
             $data = $this->httpGet($uri);
-            if($canAcessRedis) {
+            if ($canAcessRedis) {
                 $cache->set($cacheKey, $data, $this->cacheLifeTime);
             }
         }
@@ -106,16 +107,15 @@ class RemoteConfig
             );
             $cache->set($cacheKey, json_decode($response->getBody(), true), self::RC_CACHE_FALLBACK_TTL);
         } catch (ConnectException $e) {
+
+            if (empty($currentCache)) {
+                throw $e;
+            }
+
             $cache->set($cacheKey, $currentCache, self::RC_CACHE_FALLBACK_TTL);
         }
 
-        $data = $cache->get($cacheKey);
-
-        if(!$data) {
-            throw new \Exception("Connection error on: '{$this->host}{$path}'");
-        }
-
-        return $data;
+        return $cache->get($cacheKey);
     }
 
     private function cacheFallback()

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -154,7 +154,7 @@ class RemoteConfig
                 'timeout' => $timeout,
             ]);
             if ($re->hasResponse()) {
-                if ($re->getResponse()->getStatusCode() === 400) {
+                if ($re->getResponse()->getStatusCode() === 404) {
                     throw new HttpException(404, "clienteId is invalid!");
                 }
             }

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -36,7 +36,7 @@ class RemoteConfig
 
     public function getClientConfig(string $client, string $config = null)
     {
-        $uri = "api/v1/configs/{$this->application}/{$client}/{$this->environment}";
+        $uri = "/api/v1/configs/{$this->application}/{$client}/{$this->environment}";
 
         $cacheKey = md5($uri);
 
@@ -52,7 +52,7 @@ class RemoteConfig
 
     private function httpGet($path)
     {
-        $response = $this->getHttpClient()->request('GET', $path, ['auth' => [$this->username, $this->password]]);
+        $response = $this->getHttpClient()->request('GET', $this->host . $path, ['auth' => [$this->username, $this->password]]);
 
         return json_decode($response->getBody(), true);
     }
@@ -63,9 +63,7 @@ class RemoteConfig
             return $this->httpClient;
         }
 
-        $httpClient = new Client([
-            'base_uri' => $this->host,
-        ]);
+        $httpClient = new Client();
 
         return $this->httpClient = $httpClient;
     }

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -5,6 +5,8 @@ namespace Linx\RemoteConfigClient;
 use GuzzleHttp\Client;
 use Symfony\Component\Cache\Simple\FilesystemCache;
 use Psr\SimpleCache\CacheInterface;
+use GuzzleHttp\Exception\ConnectException;
+use Exception;
 
 class RemoteConfig
 {
@@ -47,7 +49,11 @@ class RemoteConfig
         if ($cache->has($cacheKey)) {
             $data = $cache->get($cacheKey);
         } else {
-            $data = $this->httpGet($uri);
+            try {
+                $data = $this->httpGet($uri);
+            } catch (ConnectException $e) {
+                 throw new \Exception("Connection error on: '{$this->host}{$uri}'. \n {$e->getMessage()}");
+            }
             $cache->set($cacheKey, $data, $this->cacheLifeTime);
         }
 

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -25,7 +25,7 @@ class RemoteConfig
 
     public function __construct(array $credentials)
     {
-        $this->host = $credentials['host'];
+        $this->host = $this->addScheme($credentials['host']);
         $this->username = $credentials['username'];
         $this->password = $credentials['password'];
         $this->application = $credentials['application'];
@@ -87,5 +87,12 @@ class RemoteConfig
     public function setCache(FilesystemCache $cache)
     {
         $this->cache = $cache;
+    }
+
+    private function addScheme($url, $scheme = 'http://')
+    {
+        return parse_url($url, PHP_URL_SCHEME) === null
+        ? $scheme . $url
+        : $url;
     }
 }

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -7,6 +7,8 @@ use Symfony\Component\Cache\Simple\FilesystemCache;
 
 class RemoteConfig
 {
+    const REQUEST_TIMEOUT = 1; // seconds
+
     private $host;
 
     private $username;
@@ -52,7 +54,15 @@ class RemoteConfig
 
     private function httpGet($path)
     {
-        $response = $this->getHttpClient()->request('GET', $this->host . $path, ['auth' => [$this->username, $this->password]]);
+        $response = $this->getHttpClient()->request(
+            'GET',
+            $this->host . $path, [
+                'auth' => [ $this->username, $this->password ],
+                'connect_timeout' => self::REQUEST_TIMEOUT,
+                'read_timeout' => self::REQUEST_TIMEOUT,
+                'timeout' => self::REQUEST_TIMEOUT,
+            ]
+        );
 
         return json_decode($response->getBody(), true);
     }

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -4,6 +4,7 @@ namespace Linx\RemoteConfigClient;
 
 use GuzzleHttp\Client;
 use Symfony\Component\Cache\Simple\FilesystemCache;
+use Psr\SimpleCache\CacheInterface;
 
 class RemoteConfig
 {
@@ -46,7 +47,7 @@ class RemoteConfig
             $data = $this->getCache()->get($cacheKey);
         } else {
             $data = $this->httpGet($uri);
-            $this->getCache()->set($cacheKey, $data);
+            $this->getCache()->set($cacheKey, $data, $this->cacheLifeTime);
         }
 
         return array_get($data, $config, null);
@@ -94,7 +95,7 @@ class RemoteConfig
         $this->httpClient = $httpClient;
     }
 
-    public function setCache(FilesystemCache $cache)
+    public function setCache(CacheInterface $cache)
     {
         $this->cache = $cache;
     }

--- a/src/RemoteConfig.php
+++ b/src/RemoteConfig.php
@@ -6,11 +6,12 @@ use GuzzleHttp\Client;
 use Symfony\Component\Cache\Simple\FilesystemCache;
 use Psr\SimpleCache\CacheInterface;
 use GuzzleHttp\Exception\ConnectException;
-use Exception;
 
 class RemoteConfig
 {
     const REQUEST_TIMEOUT = 3; // seconds
+
+    const REQUEST_URI = '/api/v1/configs/%s/%s/%s';
 
     private $host;
 
@@ -41,10 +42,13 @@ class RemoteConfig
 
     public function getClientConfig(string $client, string $config = null)
     {
-        $uri = "/api/v1/configs/{$this->application}/{$client}/{$this->environment}";
-        $cacheKey = md5($uri);
+        $uri = $this->buildUri($this->application, $client, $this->environment);
+        $cacheKey = $this->buildCacheKey($uri);
 
-        $cache = $this->getCache()->tags($this->getCacheTags($client));
+        $cache = $this->getCache();
+        if (method_exists($cache, 'tags')) {
+            $cache = $cache->tags($this->getCacheTags($client));
+        }
 
         if ($cache->has($cacheKey)) {
             $data = $cache->get($cacheKey);
@@ -52,7 +56,7 @@ class RemoteConfig
             try {
                 $data = $this->httpGet($uri);
             } catch (ConnectException $e) {
-                 throw new \Exception("Connection error on: '{$this->host}{$uri}'. \n {$e->getMessage()}");
+                throw new \Exception("Connection error on: '{$this->host}{$uri}'. \n {$e->getMessage()}");
             }
             $cache->set($cacheKey, $data, $this->cacheLifeTime);
         }
@@ -62,15 +66,16 @@ class RemoteConfig
 
     private function getCacheTags($client)
     {
-        return [ $client, "{$client}-remoteconfig" ];
+        return [$client, "{$client}-remoteconfig"];
     }
 
     private function httpGet($path)
     {
         $response = $this->getHttpClient()->request(
             'GET',
-            $this->host . $path, [
-                'auth' => [ $this->username, $this->password ],
+            $this->host . $path,
+            [
+                'auth' => [$this->username, $this->password],
                 'connect_timeout' => self::REQUEST_TIMEOUT,
                 'read_timeout' => self::REQUEST_TIMEOUT,
                 'timeout' => self::REQUEST_TIMEOUT,
@@ -112,10 +117,43 @@ class RemoteConfig
         $this->cache = $cache;
     }
 
+    public function updateCacheData(string $client, array $data, bool $canExpire = true)
+    {
+        $uri = $this->buildUri($this->application, $client, $this->environment);
+        $cacheKey = $this->buildCacheKey($uri);
+
+        $cache = $this->getCache();
+        if (method_exists($cache, 'tags')) {
+            $cache = $cache->tags($this->getCacheTags($client));
+        }
+
+        $cacheLifeTime = $canExpire ? $this->cacheLifeTime : null;
+
+        $cache->set($cacheKey, $data, $cacheLifeTime);
+    }
+
     private function addScheme($url, $scheme = 'http://')
     {
         return parse_url($url, PHP_URL_SCHEME) === null
-        ? $scheme . $url
-        : $url;
+            ? $scheme . $url
+            : $url;
+    }
+
+    private function buildUri(
+        string $application,
+        string $client,
+        string $environment
+    ): string {
+        return sprintf(
+            self::REQUEST_URI,
+            $application,
+            $client,
+            $environment
+        );
+    }
+
+    private function buildCacheKey(string $uri): string
+    {
+        return md5($uri);
     }
 }

--- a/src/RemoteConfigFacade.php
+++ b/src/RemoteConfigFacade.php
@@ -13,6 +13,6 @@ class RemoteConfigFacade extends Facade
      */
     protected static function getFacadeAccessor()
     {
-        return 'remoteConfig';
+        return RemoteConfig::class;
     }
 }

--- a/src/RemoteConfigServiceProvider.php
+++ b/src/RemoteConfigServiceProvider.php
@@ -18,10 +18,8 @@ class RemoteConfigServiceProvider extends ServiceProvider
             $remoteConfig = new RemoteConfig($config);
             $remoteConfig->setCache(Cache::getFacadeRoot()->store());
 
-            $loggerClass = $config['logger-class'] ?? null;
-            if ($loggerClass && $app->make($loggerClass) instanceof Log) {
-                $remoteConfig->setLoggerClass($loggerClass);
-            }
+            $loggerClass = $config['logger-class'] ?? '';
+            $remoteConfig->setLoggerClass($loggerClass);
 
             return $remoteConfig;
         });

--- a/src/RemoteConfigServiceProvider.php
+++ b/src/RemoteConfigServiceProvider.php
@@ -4,6 +4,7 @@ namespace Linx\RemoteConfigClient;
 
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Cache;
+use Laravel\Lumen\Application;
 
 class RemoteConfigServiceProvider extends ServiceProvider
 {
@@ -11,7 +12,7 @@ class RemoteConfigServiceProvider extends ServiceProvider
     {
         $source = dirname(__DIR__).'/config/remote-config.php';
 
-        if ($this->app instanceof LumenApplication) {
+        if ($this->app instanceof Application) {
             $this->app->configure('remote-config');
         }
 

--- a/src/RemoteConfigServiceProvider.php
+++ b/src/RemoteConfigServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace Linx\RemoteConfigClient;
 
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Cache;
 use Laravel\Lumen\Application;
@@ -16,6 +17,11 @@ class RemoteConfigServiceProvider extends ServiceProvider
             $config = $app->make('config')->get('remote-config');
             $remoteConfig = new RemoteConfig($config);
             $remoteConfig->setCache(Cache::getFacadeRoot()->store());
+
+            $loggerClass = $config['logger-class'] ?? null;
+            if ($loggerClass && $app->make($loggerClass) instanceof Log) {
+                $remoteConfig->setLoggerClass($loggerClass);
+            }
 
             return $remoteConfig;
         });

--- a/src/RemoteConfigServiceProvider.php
+++ b/src/RemoteConfigServiceProvider.php
@@ -8,25 +8,27 @@ use Laravel\Lumen\Application;
 
 class RemoteConfigServiceProvider extends ServiceProvider
 {
-    public function boot()
-    {
-        $source = dirname(__DIR__).'/config/remote-config.php';
-
-        if ($this->app instanceof Application) {
-            $this->app->configure('remote-config');
-        }
-
-        $this->mergeConfigFrom($source, 'remote-config');
-    }
-
     public function register()
     {
         $this->app->singleton(RemoteConfig::class, function ($app) {
+            $this->configure($app);
+
             $config = $app->make('config')->get('remote-config');
             $remoteConfig = new RemoteConfig($config);
             $remoteConfig->setCache(Cache::getFacadeRoot()->store());
 
             return $remoteConfig;
         });
+    }
+
+    private function configure($app)
+    {
+        $source = dirname(__DIR__).'/config/remote-config.php';
+
+        if ($app instanceof Application) {
+            $app->configure('remote-config');
+        }
+
+        $this->mergeConfigFrom($source, 'remote-config');
     }
 }

--- a/src/RemoteConfigServiceProvider.php
+++ b/src/RemoteConfigServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Linx\RemoteConfigClient;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Cache;
 
 class RemoteConfigServiceProvider extends ServiceProvider
 {
@@ -21,7 +22,10 @@ class RemoteConfigServiceProvider extends ServiceProvider
     {
         $this->app->singleton(RemoteConfig::class, function ($app) {
             $config = $app->make('config')->get('remote-config');
-            return new RemoteConfig($config);
+            $remoteConfig = new RemoteConfig($config);
+            $remoteConfig->setCache(Cache::getFacadeRoot()->store());
+
+            return $remoteConfig;
         });
     }
 }

--- a/tests/RemoteConfigTest.php
+++ b/tests/RemoteConfigTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Psr7\Request;
+use Illuminate\Support\Facades\Log;
 use Linx\RemoteConfigClient\RemoteConfig;
 use GuzzleHttp\Client;
 use Symfony\Component\Cache\Simple\FilesystemCache;
@@ -54,6 +57,65 @@ class RemoteConfigTest extends PHPUnit_Framework_TestCase
             ->once()
             ->andReturn(true);
 
+        $remoteConfig->getClientConfig('client');
+    }
+
+    public function testLogWhenFails()
+    {
+        $remoteConfig = new RemoteConfig([
+            'host' => 'http://remote-config',
+            'username' => 'username@email.com',
+            'password' => 'password',
+            'application' => 'application2',
+            'environment' => 'environment',
+        ]);
+
+        $cacheMock = Mockery::mock(FilesystemCache::class);
+        $httpClientMock = Mockery::mock(Client::class);
+
+        $remoteConfig->setHttpClient($httpClientMock);
+        $remoteConfig->setCache($cacheMock);
+        $remoteConfig->setLoggerClass(Log::class);
+
+        $cacheMock
+            ->shouldReceive('has')
+            ->with(md5('/api/v1/configs/application2/client/environment'))
+            ->once()
+            ->andThrow(Exception::class, 'Testing Exception');
+
+        Log::shouldReceive('error')
+            ->withArgs(['Could not open cache from Redis', [
+                'client' => 'client',
+                'error_message' => 'Testing Exception',
+                'uri' => '/api/v1/configs/application2/client/environment',
+            ]])
+            ->once()
+            ->getMock()
+            ->shouldReceive('error')
+            ->withArgs(['Could not get data from Remote Config API', [
+                'current_cache' => null,
+                'error_message' => 'Testing ConnectException',
+                'path' => '/api/v1/configs/application2/client/environment',
+                'timeout' => 3,
+            ]])
+            ->once();
+
+        $httpClientMock
+            ->shouldReceive('request')
+            ->with('GET', 'http://remote-config/api/v1/configs/application2/client/environment', [
+                'auth' => ['username@email.com', 'password'],
+                'connect_timeout' => RemoteConfig::REQUEST_TIMEOUT,
+                'read_timeout' => RemoteConfig::REQUEST_TIMEOUT,
+                'timeout' => RemoteConfig::REQUEST_TIMEOUT,
+            ])
+            ->once()
+            ->andThrow(
+                ConnectException::class,
+                'Testing ConnectException',
+                new Request('http://remote-config', '/api/v1/configs/application2/client/environment')
+            );
+
+        self::expectException(ConnectException::class);
         $remoteConfig->getClientConfig('client');
     }
 }

--- a/tests/RemoteConfigTest.php
+++ b/tests/RemoteConfigTest.php
@@ -29,13 +29,18 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 
         $cacheMock
             ->shouldReceive('has')
-            ->with(md5('api/v1/configs/application/client/environment'))
+            ->with(md5('/api/v1/configs/application/client/environment'))
             ->once()
             ->andReturn(false);
 
         $httpClientMock
             ->shouldReceive('request')
-            ->with('GET', 'api/v1/configs/application/client/environment', ['auth' => ['username@email.com', 'password']])
+            ->with('GET', 'http://remote-config/api/v1/configs/application/client/environment', [
+                'auth' => ['username@email.com', 'password'],
+                'connect_timeout' => RemoteConfig::REQUEST_TIMEOUT,
+                'read_timeout' => RemoteConfig::REQUEST_TIMEOUT,
+                'timeout' => RemoteConfig::REQUEST_TIMEOUT,
+                ])
             ->once()
             ->andReturn(Mockery::self())
             ->getMock()
@@ -45,7 +50,7 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
 
         $cacheMock
             ->shouldReceive('set')
-            ->with(md5('api/v1/configs/application/client/environment'), [])
+            ->with(md5('/api/v1/configs/application/client/environment'), [], 3600)
             ->once()
             ->andReturn(true);
 

--- a/tests/RemoteConfigTest.php
+++ b/tests/RemoteConfigTest.php
@@ -33,6 +33,12 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
             ->once()
             ->andReturn(false);
 
+        $cacheMock
+            ->shouldReceive('tags')
+            ->with(['client', "client-remoteconfig"])
+            ->once()
+            ->andReturn($cacheMock);
+
         $httpClientMock
             ->shouldReceive('request')
             ->with('GET', 'http://remote-config/api/v1/configs/application/client/environment', [

--- a/tests/RemoteConfigTest.php
+++ b/tests/RemoteConfigTest.php
@@ -4,7 +4,7 @@ use Linx\RemoteConfigClient\RemoteConfig;
 use GuzzleHttp\Client;
 use Symfony\Component\Cache\Simple\FilesystemCache;
 
-class FormBuilderTest extends PHPUnit_Framework_TestCase
+class RemoteConfigTest extends PHPUnit_Framework_TestCase
 {
     public function tearDown()
     {
@@ -33,12 +33,6 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
             ->once()
             ->andReturn(false);
 
-        $cacheMock
-            ->shouldReceive('tags')
-            ->with(['client', "client-remoteconfig"])
-            ->once()
-            ->andReturn($cacheMock);
-
         $httpClientMock
             ->shouldReceive('request')
             ->with('GET', 'http://remote-config/api/v1/configs/application/client/environment', [
@@ -48,15 +42,15 @@ class FormBuilderTest extends PHPUnit_Framework_TestCase
                 'timeout' => RemoteConfig::REQUEST_TIMEOUT,
                 ])
             ->once()
-            ->andReturn(Mockery::self())
+            ->andReturnSelf()
             ->getMock()
             ->shouldReceive('getBody')
             ->once()
-            ->andReturn('{}');
+            ->andReturn('{"key": "value"}');
 
         $cacheMock
             ->shouldReceive('set')
-            ->with(md5('/api/v1/configs/application/client/environment'), [], 3600)
+            ->with(md5('/api/v1/configs/application/client/environment'), ['key' => 'value'], -1)
             ->once()
             ->andReturn(true);
 

--- a/tests/RemoteConfigTest.php
+++ b/tests/RemoteConfigTest.php
@@ -1,22 +1,54 @@
 <?php
 
 use Linx\RemoteConfigClient\RemoteConfig;
+use GuzzleHttp\Client;
+use Symfony\Component\Cache\Simple\FilesystemCache;
 
 class FormBuilderTest extends PHPUnit_Framework_TestCase
 {
-    public function testRequestValue()
+    public function tearDown()
+    {
+        Mockery::close();
+    }
+
+    public function testGetClientConfig()
     {
         $remoteConfig = new RemoteConfig([
-            'host' => 'http://127.0.0.1:8000',
-            'username' => 'client@email',
-            'password' => '123456',
+            'host' => 'http://remote-config',
+            'username' => 'username@email.com',
+            'password' => 'password',
             'application' => 'application',
-            'environment' =>  'development',
+            'environment' => 'environment',
         ]);
 
+        $cacheMock = Mockery::mock(FilesystemCache::class);
+        $httpClientMock = Mockery::mock(Client::class);
+
+        $remoteConfig->setHttpClient($httpClientMock);
+        $remoteConfig->setCache($cacheMock);
+
+        $cacheMock
+            ->shouldReceive('has')
+            ->with(md5('api/v1/configs/application/client/environment'))
+            ->once()
+            ->andReturn(false);
+
+        $httpClientMock
+            ->shouldReceive('request')
+            ->with('GET', 'api/v1/configs/application/client/environment', ['auth' => ['username@email.com', 'password']])
+            ->once()
+            ->andReturn(Mockery::self())
+            ->getMock()
+            ->shouldReceive('getBody')
+            ->once()
+            ->andReturn('{}');
+
+        $cacheMock
+            ->shouldReceive('set')
+            ->with(md5('api/v1/configs/application/client/environment'), [])
+            ->once()
+            ->andReturn(true);
+
         $remoteConfig->getClientConfig('client');
-
-
-        $this->assertEquals('foo', $remoteConfig->get()['test']);
     }
 }


### PR DESCRIPTION
In the RemoteConfig class, I made a new exception to catch the Http errors, and with that I was able to correctly throw the 404 error with the message clientId is invalid.